### PR TITLE
Better Webpack Support: Allow Relative Paths

### DIFF
--- a/lib/find-retina-image.js
+++ b/lib/find-retina-image.js
@@ -1,4 +1,4 @@
-import { basename, dirname, extname, join } from 'path';
+import { basename, extname, join } from 'path';
 import { accessSync } from 'fs';
 
 function fileExists(file) {
@@ -10,16 +10,15 @@ function fileExists(file) {
   }
 }
 
-export default function findRetinaImage(filePath, retinaSuffixes = ['@2x']) {
+export default function findRetinaImage(filePath, assetDirectory, retinaSuffixes = ['@2x']) {
   if (typeof retinaSuffixes === 'string') {
     retinaSuffixes = [retinaSuffixes];
   }
 
-  const fileDirectory = dirname(filePath);
   const fileExtension = extname(filePath);
   const fileName = basename(filePath, fileExtension);
 
   return retinaSuffixes
-    .map((suffix) => join(fileDirectory, fileName + suffix + fileExtension))
-    .find((retinaFileName) => fileExists(retinaFileName));
+    .map((suffix) => filePath.replace(fileName, fileName + suffix))
+    .find((retinaFileName) => fileExists(join(assetDirectory, retinaFileName)));
 }

--- a/lib/postcss-plugin.js
+++ b/lib/postcss-plugin.js
@@ -3,7 +3,7 @@ import postcss from 'postcss';
 
 import findRetinaImage from './find-retina-image';
 import { distributeQueryAcrossQuery, queryCoversRange, nodeIsMediaQuery } from './utils/media-query';
-import { isFullUrlPath, isAbsoluteFilePath, makeAbsoluteFilePath } from './utils/image-url';
+import { isFullUrlPath } from './utils/image-url';
 
 const UNNECESSARY_RETINA_IMAGE_WARNING = 'Unncessary retina image provided; the same will be generated automatically';
 const DEFAULT_MEDIA_QUERY = '(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)';
@@ -115,27 +115,21 @@ function retinaBackgroundImage(options) {
           return;
         }
 
-        let relativeRetinaPath = retinaImagePath.replace(assetDirectory, '');
-
         // Prune out instances where the rule has been defined explicitly; no need to generate a new media query
         if (ruleBlacklist[mediaQuery] && ruleBlacklist[mediaQuery][selector]) {
           const { imgPath, decl: existingDecl } = ruleBlacklist[mediaQuery][selector];
 
-          if (imgPath === relativeRetinaPath) {
+          if (imgPath === retinaImagePath) {
             existingDecl.warn(result, UNNECESSARY_RETINA_IMAGE_WARNING);
           }
 
           return;
         }
 
-        if (isAbsoluteFilePath(relativeImagePath)) {
-          relativeRetinaPath = makeAbsoluteFilePath(relativeRetinaPath);
-        }
-
         // Create the new property
         const retinaImageDecl = postcss.decl({
           prop: PROPERTY_TRANSLATIONS[prop],
-          value: `url('${relativeRetinaPath}');`
+          value: `url('${retinaImagePath}');`
         });
 
         ruleInMediaQuery.append(retinaImageDecl);

--- a/lib/postcss-plugin.js
+++ b/lib/postcss-plugin.js
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { dirname } from 'path';
 import postcss from 'postcss';
 
 import findRetinaImage from './find-retina-image';
@@ -29,14 +29,19 @@ function missingRetinaImageWarning(image) {
 
 function retinaBackgroundImage(options) {
   return function(root, result) {
+    const ruleSource = root.source.input.file;
     const retinaSuffix = options.retinaSuffix || DEFAULT_RETINA_SUFFIX;
     const mediaQueryOption = options.mediaQuery || DEFAULT_MEDIA_QUERY;
-    const assetDirectory = options.assetDirectory;
     const ruleBlacklist = {};
+    let assetDirectory = options.assetDirectory;
     let newMediaQueries = [];
 
     if (!assetDirectory) {
-      throw new Error('You must provide an asset directory');
+      if (typeof ruleSource === 'string') {
+        assetDirectory = dirname(ruleSource);
+      } else {
+        throw new Error('You must provide an asset directory');
+      }
     }
 
     root.walkAtRules('media', function(atRule) {
@@ -102,8 +107,7 @@ function retinaBackgroundImage(options) {
           return;
         }
 
-        const absoluteImagePath = join(assetDirectory, relativeImagePath);
-        const retinaImagePath = findRetinaImage(absoluteImagePath, retinaSuffix);
+        const retinaImagePath = findRetinaImage(relativeImagePath, assetDirectory, retinaSuffix);
 
         // Abort if we couldn't find the retina version of the image
         if (!retinaImagePath) {
@@ -111,7 +115,7 @@ function retinaBackgroundImage(options) {
           return;
         }
 
-        let relativeRetinaPath = retinaImagePath.replace(assetDirectory, '').substring(1);
+        let relativeRetinaPath = retinaImagePath.replace(assetDirectory, '');
 
         // Prune out instances where the rule has been defined explicitly; no need to generate a new media query
         if (ruleBlacklist[mediaQuery] && ruleBlacklist[mediaQuery][selector]) {

--- a/tests/find-retina-image.js
+++ b/tests/find-retina-image.js
@@ -5,34 +5,38 @@ import { expect } from 'chai';
 
 import findRetinaImage from '../lib/find-retina-image.js';
 
-function fixturePath(fileName) {
-  return path.join(__dirname, 'fixtures', fileName);
-}
+const fixturePath = path.join(__dirname, 'fixtures');
 
 describe('finding the retina image', function() {
-  it('works when a single suffix is provided', function() {
-    const retinaName = findRetinaImage(fixturePath('file-with-one-retina.txt'), '@2x');
+  it('works with relative paths', function() {
+    const retinaName = findRetinaImage('./file-with-one-retina.txt', fixturePath, '@2x');
 
-    expect(retinaName).to.equal(fixturePath('file-with-one-retina@2x.txt'));
+    expect(retinaName).to.equal('./file-with-one-retina@2x.txt');
+  });
+
+  it('works when a single suffix is provided', function() {
+    const retinaName = findRetinaImage('file-with-one-retina.txt', fixturePath, '@2x');
+
+    expect(retinaName).to.equal('file-with-one-retina@2x.txt');
   });
 
   it('works when multiple suffixes are provided', function() {
-    const retinaName = findRetinaImage(fixturePath('file-with-other-retina.txt'), ['@2x', '_2x']);
+    const retinaName = findRetinaImage('file-with-other-retina.txt', fixturePath, ['@2x', '_2x']);
 
-    expect(retinaName).to.equal(fixturePath('file-with-other-retina_2x.txt'));
+    expect(retinaName).to.equal('file-with-other-retina_2x.txt');
   });
 
   it('fails to locate a file without a matching retina version', function() {
-    const retinaName = findRetinaImage(fixturePath('file-without-retina.txt'), '@2x');
+    const retinaName = findRetinaImage('file-without-retina.txt', fixturePath, '@2x');
 
     expect(retinaName).to.be.undefined;
   });
 
   describe('default options', function() {
     it('falls back to using `@2x` for the retina suffix', function() {
-      const retinaName = findRetinaImage(fixturePath('file-with-one-retina.txt'));
+      const retinaName = findRetinaImage('file-with-one-retina.txt', fixturePath);
 
-      expect(retinaName).to.equal(fixturePath('file-with-one-retina@2x.txt'));
+      expect(retinaName).to.equal('file-with-one-retina@2x.txt');
     });
   });
 });

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -10,7 +10,7 @@ export const baseOptions = {
 
 export function run(input, options) {
   return postcss([ bgImage(options) ])
-    .process(input)
+    .process(input, {from: 'tests/test.css'})
     .then((result) => {
       return {
         output: postcss.parse(result.css),

--- a/tests/postcss-plugin.js
+++ b/tests/postcss-plugin.js
@@ -94,6 +94,22 @@ describe('PostCSS Plugin', function() {
         expect(output.nodes.length).to.equal(2);
       });
     });
+
+    it('finds images with relative paths', function() {
+      const css = `
+        a {
+          background-image: url('./fixtures/file-with-one-retina.txt');
+        }
+      `;
+
+      return run(css, {}).then(function({ output }) {
+        const [ , mq ] = output.nodes;
+        const [ retinaRule ] = mq.nodes;
+        const [ bgDecl ] = retinaRule.nodes;
+
+        expect(bgDecl.value).to.equal("url('./fixtures/file-with-one-retina@2x.txt')");
+      });
+    });
   });
 
   describe('`background-image` property', function() {


### PR DESCRIPTION
This PR makes `assetDirectory` optional by allowing file URLs relative to the location of the stylesheet if no `assetDirectory` is provided. This supports the modular CSS approach favored for Webpack and other build tools.

I've left the initial PR as 4 distinct commits to show my thinking and will squash prior to merge.

Changes:
 * `findRetinaImage` takes `assetDirectory` as an argument since it is only used for file discovery. 
 * Instead of returning a full path, `findRetinaImage` now returns the original (relative) path with the `@2x` suffix added (or whichever suffix was provided.)

I believe I've left all previous behavior intact; please let me know if there is anything that needs changes. Thanks!